### PR TITLE
Put chatroomName back in URL params since the error with non-alphanum…

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -36,7 +36,7 @@ return (
     <HeaderWrapper>
         <Router>
           <Route exact path="/" component={Home}/>
-          <PrivateRoute exact path="/dashboard/:chatroomID" component={Dashboard}/>
+          <PrivateRoute exact path="/dashboard/:chatroomName/:chatroomID" component={Dashboard}/>
           <PrivateRoute exact path="/dashboard" component={Dashboard}/>
           <PublicRoute exact path="/login" component={Login}/>
           <PublicRoute exact path="/register" component={Register}/>

--- a/client/src/components/SideBarChatrooms/SideBarChatrooms.js
+++ b/client/src/components/SideBarChatrooms/SideBarChatrooms.js
@@ -23,7 +23,7 @@ function SideBarChatrooms({ chatrooms }) {
                     
                     {chatrooms.map((chatroom, index) => {
                         return (
-                            <Link to={`/dashboard/${chatroom.chatroomID}`}>
+                            <Link to={`/dashboard/${chatroom.chatroomName}/${chatroom.chatroomID}`}>
                                 <div>
                                     <ListGroup.Item 
                                         key={index} 


### PR DESCRIPTION
…eric symbols was fixed with validation while adding chatrooms; This means the chatroom name displays when in a chatroom.